### PR TITLE
docs: Cleanup the not used variants for the UTF-8 migration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -119,9 +119,9 @@ commands    =
     coverage xml  -o {envlogdir}/coverage.xml  --fail-under {env:XCP_COVERAGE_MIN:78}
     coverage lcov -o {envlogdir}/coverage.lcov
     coverage html -d {envlogdir}/htmlcov
-    coverage html -d {envlogdir}/htmlcov-tests --fail-under {env:TESTS_COVERAGE_MIN:96} \
+    coverage html -d {envlogdir}/htmlcov-tests --fail-under {env:TESTS_COVERAGE_MIN:95} \
                       --include="tests/*"
-    diff-cover --compare-branch=origin/master --exclude xcp/dmv.py                    \
+    diff-cover --compare-branch=origin/master                                         \
       {env:PY3_DIFFCOVER_OPTIONS} --fail-under {env:DIFF_COVERAGE_MIN:92}             \
       --html-report  {envlogdir}/coverage-diff.html                                   \
                      {envlogdir}/coverage.xml


### PR DESCRIPTION
docs: Cleanup the not used variants for the UTF-8 migration